### PR TITLE
Implement intralinks for reference-style links

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@
 use itertools::Itertools;
 use std::ops::Range;
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Ord, PartialOrd)]
 pub struct Span {
     pub start: usize,
     pub end: usize,


### PR DESCRIPTION
Resolves #163

I did things a little differently than you suggested. I made `MarkdownInlineLink` look like this:
```rust
struct MarkdownInlineLink {
    text: String,
    inner: MarkdownLink,
}

struct MarkdownLink {
    raw_link: String,
}
```
This seemed sensible to me since:
1. The existing `MarkdownInlineLink` methods did not use `text` and thus could become `MarkdownLink` methods.
2. The `markdown_link` function could be modified to take a `MarkdownLink` as its first argument and thus be used in a new function, `rewrite_reference_definitions`, analogous to `rewrite_markdown_links`.

A point of note: `rewrite_reference_definitions` iterates using `Parser::reference_definitions`. However, the iterator that method returns retains a reference to the parser. As such, the code that would have gone into a `markdown_reference_definitions_iterator` function (analogous to `markdown_inline_link_iterator`) is instead inlined into `rewrite_reference_definitions`. Getting lifetimes to work for a `markdown_reference_definitions_iterator` function would seem to require non-trivial changes.

Hopefully, everything else is straightforward. Nits are welcome.