### PR TITLE
Add support for `rustdoc` shorthand link syntax & deps bump

### DIFF
--- a/src/transform/intralinks/mod.rs
+++ b/src/transform/intralinks/mod.rs
@@ -84,15 +84,21 @@ where
     type E = IntralinkError;
 
     fn transform(&self, doc: &Doc) -> Result<Doc, IntralinkError> {
-        let symbols: HashSet<ItemPath> = extract_markdown_intralink_symbols(doc);
+        let mut symbols: HashSet<ItemPath> = extract_markdown_intralink_symbols(doc);
 
-        // If there are no intralinks in the doc don't even bother doing anything else.
-        if symbols.is_empty() {
+        let strip_links = self.config.strip_links.unwrap_or(false);
+
+        // Also extract shorthand [`code`] patterns and add them as potential symbols.
+        let shorthand_symbols = extract_shorthand_symbols(doc);
+        symbols.extend(shorthand_symbols);
+
+        // If there are no links at all and we're not stripping, nothing to do.
+        if symbols.is_empty() && !strip_links {
             return Ok(doc.clone());
         }
 
         // We only load symbols type information when we need them.
-        let symbols_type = match self.config.strip_links.unwrap_or(false) {
+        let symbols_type = match strip_links {
             false => load_symbols_type(&self.entrypoint, &symbols, &self.emit_warning)?,
             true => HashMap::new(),
         };
@@ -100,8 +106,171 @@ where
         let doc =
             rewrite_links(doc, &symbols_type, &self.crate_name, &self.emit_warning, &self.config);
 
+        // Post-process the document to handle shorthand [`code`] patterns.
+        // This must handle standalone patterns but skip patterns that are already part of links.
+        let doc = post_process_shorthand_links(
+            &doc,
+            &symbols_type,
+            &self.crate_name,
+            &self.emit_warning,
+            &self.config,
+            strip_links,
+        );
+
         Ok(doc)
     }
+}
+
+/// Collect the inner code of every rustdoc reference *definition* of the form `` [`code`]: ... ``
+/// that appears at the start of a line.
+///
+/// Both the definition itself and any shortcut usages that resolve through it must be left
+/// untouched by the shorthand pass, otherwise we would corrupt reference links the user wrote on
+/// purpose (turning `` [`Foo`]: url `` into `` [`Foo`](url): url ``).
+fn shorthand_reference_definitions(text: &str) -> HashSet<&str> {
+    let mut defined = HashSet::new();
+
+    for line in text.lines() {
+        let Some(rest) = line.trim_start().strip_prefix("[`") else { continue };
+        let Some(end) = rest.find("`]") else { continue };
+
+        // It is a reference definition only if the closing `]` is immediately followed by `:`.
+        if rest[end + 2..].starts_with(':') {
+            defined.insert(&rest[..end]);
+        }
+    }
+
+    defined
+}
+
+/// Iterate over all `` [`code`] `` shorthand patterns in `text` that are genuine standalone
+/// shorthands, yielding `(start, end, code)` byte positions for each.
+///
+/// A `` [`code`] `` pattern is *not* a standalone shorthand (and is therefore skipped) when it is
+/// actually part of a markdown link or reference construct:
+///
+/// * `` [`code`](url) `` -- an inline link (`(` immediately follows the closing `]`).
+/// * `` [`code`][label] `` -- a full or collapsed reference link (`[` immediately follows).
+/// * `` [`code`] `` together with a `` [`code`]: ... `` definition -- a shortcut reference link.
+///
+/// Note that markdown requires the `(`/`[` to *immediately* follow the closing `]`; a space in
+/// between (e.g. `` [`f()`] (fast) ``) means it is not a link, so such patterns are still
+/// recognized as shorthands.
+fn shorthand_patterns(text: &str) -> impl Iterator<Item = (usize, usize, &str)> {
+    let defined = shorthand_reference_definitions(text);
+    let mut offset = 0;
+    let mut remaining = text;
+
+    std::iter::from_fn(move || {
+        while let Some(start_idx) = remaining.find("[`") {
+            let after_start = &remaining[start_idx + 2..];
+
+            let Some(end_idx) = after_start.find("`]") else {
+                // No closing `` `] ``: skip this `` [` `` and keep looking.
+                let consumed = start_idx + 2;
+                remaining = &remaining[consumed..];
+                offset += consumed;
+                continue;
+            };
+
+            let content = &after_start[..end_idx];
+            let after_pattern = &after_start[end_idx + 2..];
+            let start = offset + start_idx;
+            let end = start + 2 + end_idx + 2;
+
+            let consumed = start_idx + 2 + end_idx + 2;
+            remaining = &remaining[consumed..];
+            offset += consumed;
+
+            let is_link_or_reference = after_pattern.starts_with('(')
+                || after_pattern.starts_with('[')
+                || defined.contains(content);
+
+            if !content.is_empty() && !is_link_or_reference {
+                return Some((start, end, content));
+            }
+        }
+        None
+    })
+}
+
+/// Extract shorthand [`code`] patterns and return them as `ItemPaths`.
+fn extract_shorthand_symbols(doc: &Doc) -> HashSet<ItemPath> {
+    shorthand_patterns(doc.as_string())
+        .filter_map(|(_, _, inner)| {
+            // Remove trailing () if present for function names.
+            let clean_name = inner.trim_end_matches("()");
+            // Add as a crate-relative symbol.
+            ItemPath::from_string(&format!("crate::{clean_name}"))
+        })
+        .collect()
+}
+
+/// Post-process the entire document to handle shorthand [`code`] patterns.
+fn post_process_shorthand_links(
+    doc: &Doc,
+    symbols_type: &HashMap<ItemPath, SymbolType>,
+    crate_name: &str,
+    emit_warning: &impl Fn(&str),
+    config: &IntralinksConfig,
+    strip_links: bool,
+) -> Doc {
+    let doc_str = doc.as_string();
+
+    // Collect the standalone shorthand patterns together with their byte positions. Patterns that
+    // are part of a markdown link or reference construct are skipped (see `shorthand_patterns`).
+    let patterns: Vec<(usize, usize, &str)> = shorthand_patterns(doc_str).collect();
+
+    // Build the result string by processing each pattern using iterators.
+    let result = std::iter::once(0)
+        .chain(patterns.iter().map(|(_, end, _)| *end))
+        .zip(patterns.iter().map(|(start, _, _)| *start).chain(std::iter::once(doc_str.len())))
+        .zip(patterns.iter().map(Some).chain(std::iter::once(None)))
+        .map(|((last_end, start), pattern_opt)| {
+            let before_text = &doc_str[last_end..start];
+
+            match pattern_opt {
+                Some(&(pattern_start, pattern_end, inner)) => {
+                    let pattern_replacement = if strip_links {
+                        // When stripping, just output the code without brackets.
+                        format!("`{inner}`")
+                    } else {
+                        // Try to generate a docs.rs link.
+                        let clean_name = inner.trim_end_matches("()");
+                        let temp_link = Link::from(format!("crate::{clean_name}"));
+
+                        let markdown_link_action = markdown_link(
+                            &temp_link,
+                            symbols_type,
+                            crate_name,
+                            emit_warning,
+                            config,
+                        );
+
+                        match markdown_link_action {
+                            MarkdownLinkAction::Link(generated_link) => {
+                                // Successfully generated a docs.rs link.
+                                format!("[`{inner}`]({generated_link})")
+                            }
+                            MarkdownLinkAction::Strip => {
+                                // Unresolvable intralink, strip to just backticked code.
+                                format!("`{inner}`")
+                            }
+                            MarkdownLinkAction::Preserve => {
+                                // Not an intralink, keep the original.
+                                doc_str[pattern_start..pattern_end].to_string()
+                            }
+                        }
+                    };
+
+                    format!("{before_text}{pattern_replacement}")
+                }
+                None => before_text.to_string(),
+            }
+        })
+        .collect::<String>();
+
+    Doc::from_str(result)
 }
 
 fn rewrite_links(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -369,6 +369,16 @@ fn integration_test_transform_intralinks_backticked() {
 }
 
 #[test]
+fn integration_test_transform_intralinks_shorthand() {
+    run_test("transform_intralinks_shorthand");
+}
+
+#[test]
+fn integration_test_transform_intralinks_shorthand_refs() {
+    run_test("transform_intralinks_shorthand_refs");
+}
+
+#[test]
 fn integration_test_option_conf_file_workspace() {
     run_test("option_conf_file_workspace");
 }

--- a/tests/transform_intralinks_shorthand/Cargo.toml
+++ b/tests/transform_intralinks_shorthand/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "integration_test"
+version = "0.0.0"
+edition = "2021"

--- a/tests/transform_intralinks_shorthand/README-expected.md
+++ b/tests/transform_intralinks_shorthand/README-expected.md
@@ -1,0 +1,29 @@
+# Shorthand Link Test
+
+<!-- cargo-rdme start -->
+
+## Shorthand Link Tests
+
+Basic shorthand links: [`my_function()`](https://docs.rs/integration_test/latest/integration_test/fn.my_function.html), [`MyStruct`](https://docs.rs/integration_test/latest/integration_test/struct.MyStruct.html), and [`MY_CONST`](https://docs.rs/integration_test/latest/integration_test/const.MY_CONST.html).
+
+Shorthand links in a list:
+- [`first_function()`](https://docs.rs/integration_test/latest/integration_test/fn.first_function.html)
+- [`second_function()`](https://docs.rs/integration_test/latest/integration_test/fn.second_function.html)
+
+Edge case: shorthand link followed by space and parenthesis (the bug we fixed):
+[`important_function()`](https://docs.rs/integration_test/latest/integration_test/fn.important_function.html) (this is very fast).
+
+Multiple on one line: [`foo()`](https://docs.rs/integration_test/latest/integration_test/fn.foo.html) and [`bar()`](https://docs.rs/integration_test/latest/integration_test/fn.bar.html) work together.
+
+Already converted (should not double-convert): [`already_linked()`](https://example.com).
+
+Not a shorthand link (no backticks): [regular link](https://example.com).
+
+Nested in text: The [`nested_func()`](https://docs.rs/integration_test/latest/integration_test/fn.nested_func.html) is useful for processing.
+
+Unresolvable links (should be stripped to just backticks):
+- `NonExistentType` should become just `NonExistentType`
+- `unresolved_function()` should become just `unresolved_function()`
+- Mixed: [`foo()`](https://docs.rs/integration_test/latest/integration_test/fn.foo.html) works but `DoesNotExist` doesn't.
+
+<!-- cargo-rdme end -->

--- a/tests/transform_intralinks_shorthand/README-template.md
+++ b/tests/transform_intralinks_shorthand/README-template.md
@@ -1,0 +1,5 @@
+# Shorthand Link Test
+
+<!-- cargo-rdme start -->
+
+<!-- cargo-rdme end -->

--- a/tests/transform_intralinks_shorthand/src/main.rs
+++ b/tests/transform_intralinks_shorthand/src/main.rs
@@ -1,0 +1,38 @@
+//! # Shorthand Link Tests
+//!
+//! Basic shorthand links: [`my_function()`], [`MyStruct`], and [`MY_CONST`].
+//!
+//! Shorthand links in a list:
+//! - [`first_function()`]
+//! - [`second_function()`]
+//!
+//! Edge case: shorthand link followed by space and parenthesis (the bug we fixed):
+//! [`important_function()`] (this is very fast).
+//!
+//! Multiple on one line: [`foo()`] and [`bar()`] work together.
+//!
+//! Already converted (should not double-convert): [`already_linked()`](https://example.com).
+//!
+//! Not a shorthand link (no backticks): [regular link](https://example.com).
+//!
+//! Nested in text: The [`nested_func()`] is useful for processing.
+//!
+//! Unresolvable links (should be stripped to just backticks):
+//! - [`NonExistentType`] should become just `NonExistentType`
+//! - [`unresolved_function()`] should become just `unresolved_function()`
+//! - Mixed: [`foo()`] works but [`DoesNotExist`] doesn't.
+
+fn my_function() {}
+fn first_function() {}
+fn second_function() {}
+fn important_function() {}
+fn foo() {}
+fn bar() {}
+fn already_linked() {}
+fn nested_func() {}
+
+struct MyStruct {}
+
+const MY_CONST: i32 = 42;
+
+fn main() {}

--- a/tests/transform_intralinks_shorthand_refs/Cargo.toml
+++ b/tests/transform_intralinks_shorthand_refs/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "integration_test"
+version = "0.0.0"
+edition = "2021"

--- a/tests/transform_intralinks_shorthand_refs/README-expected.md
+++ b/tests/transform_intralinks_shorthand_refs/README-expected.md
@@ -1,0 +1,16 @@
+# Shorthand Reference Safety Test
+
+<!-- cargo-rdme start -->
+
+The shorthand pass must not corrupt reference links or reference definitions.
+
+Bare shorthand is converted to a link: [`BareStruct`](https://docs.rs/integration_test/latest/integration_test/struct.BareStruct.html).
+
+Shortcut reference with an explicit definition is left untouched: [`DefStruct`].
+
+Full reference link is left untouched: [`RefStruct`][rs].
+
+[`DefStruct`]: https://docs.rs/integration_test/latest/integration_test/struct.DefStruct.html
+[rs]: https://docs.rs/integration_test/latest/integration_test/struct.RefStruct.html
+
+<!-- cargo-rdme end -->

--- a/tests/transform_intralinks_shorthand_refs/README-template.md
+++ b/tests/transform_intralinks_shorthand_refs/README-template.md
@@ -1,0 +1,5 @@
+# Shorthand Reference Safety Test
+
+<!-- cargo-rdme start -->
+
+<!-- cargo-rdme end -->

--- a/tests/transform_intralinks_shorthand_refs/src/main.rs
+++ b/tests/transform_intralinks_shorthand_refs/src/main.rs
@@ -1,0 +1,16 @@
+//! The shorthand pass must not corrupt reference links or reference definitions.
+//!
+//! Bare shorthand is converted to a link: [`BareStruct`].
+//!
+//! Shortcut reference with an explicit definition is left untouched: [`DefStruct`].
+//!
+//! Full reference link is left untouched: [`RefStruct`][rs].
+//!
+//! [`DefStruct`]: crate::DefStruct
+//! [rs]: crate::RefStruct
+
+struct BareStruct {}
+struct DefStruct {}
+struct RefStruct {}
+
+fn main() {}


### PR DESCRIPTION
Implemented recognition and processing of shorthand ``[`code`]`` patterns.
These patterns are now properly handled for both link stripping and `docs.rs` link generation.

Changes:
- Add detection of shorthand patterns like [`function`] in documentation.
 - Support stripping brackets from such patterns when using
   `--intralinks-strip-links` flag.
- Generate proper `docs.rs` links for recognized shorthand patterns.
- Bumped deps, small `cargo_metadata` update-related fix (sep. commit).

Used e.g. just now in `dithereens` [`README.md`](https://github.com/virtualritz/dithereens/blob/master/README.md) generated from shorthand links in its [`lib.rs`](https://github.com/virtualritz/dithereens/blob/master/src/lib.rs).