### PR TITLE
Fix `clippy::question_mark` lint in `ItemPath::from_string`

### DIFF
--- a/src/transform/intralinks/mod.rs
+++ b/src/transform/intralinks/mod.rs
@@ -163,11 +163,10 @@ impl ItemPath {
             rest = r;
         } else if s == "crate" {
             return Some(ItemPath::new(ItemPathAnchor::Crate));
-        } else if let Some(r) = s.strip_prefix("crate::") {
+        } else {
+            let r = s.strip_prefix("crate::")?;
             anchor = ItemPathAnchor::Crate;
             rest = r;
-        } else {
-            return None;
         }
 
         if rest.is_empty() {


### PR DESCRIPTION
Newer clippy flags the trailing `else { return None }` of the anchor-parsing chain in `ItemPath::from_string` as rewritable with the `?` operator (`clippy::question_mark`).

This converts the final branch to use `?` on `strip_prefix("crate::")`. It is behavior-preserving: it returns `None` in exactly the same case as before.

Independent of any feature work; applies cleanly on top of `main`.